### PR TITLE
Extra functionality

### DIFF
--- a/addon/components/rl-month-picker.js
+++ b/addon/components/rl-month-picker.js
@@ -18,6 +18,8 @@ export default Ember.Component.extend(DropdownComponentMixin, {
 
   maxYearNumber: null,
 
+  yearPicker: true,
+
   monthPlaceholderText: 'Month',
 
   monthLabels: 'Jan,Feb,Mar,Apr,May,Jun,Jul,Aug,Sep,Oct,Nov,Dec',
@@ -105,9 +107,9 @@ export default Ember.Component.extend(DropdownComponentMixin, {
   }),
 
   monthLabelsArray: Ember.computed('monthLabels', function () {
-    var monthLabels = this.get('monthLabels');
+      var monthLabels = this.get('monthLabels');
 
-    return typeof monthLabels === 'string' ? Ember.A(monthLabels.split(',')) : Ember.A(monthLabels);
+      return typeof monthLabels === 'string' ? Ember.A(monthLabels.split(',')) : Ember.A(monthLabels);
   }),
 
   decreaseMonthButtonDisabled: Ember.computed('month', 'minMonth', function () {
@@ -220,7 +222,9 @@ export default Ember.Component.extend(DropdownComponentMixin, {
     },
 
     openYearPicker: function () {
-      this.set('yearPickerMode', true);
+      if(this.get('yearPicker')){
+        this.set('yearPickerMode', true);
+      }
     },
 
     pickedYear: function (year) {

--- a/addon/components/rl-month-picker.js
+++ b/addon/components/rl-month-picker.js
@@ -28,6 +28,10 @@ export default Ember.Component.extend(DropdownComponentMixin, {
 
   monthLabels: 'Jan,Feb,Mar,Apr,May,Jun,Jul,Aug,Sep,Oct,Nov,Dec',
 
+  useLongTitle: true,
+
+  monthLabelsLong: 'January,February,March,April,May,June,July,August,September,October,November,December',
+
   flatMode: false,
 
   decreaseButtonText: '<',
@@ -113,13 +117,28 @@ export default Ember.Component.extend(DropdownComponentMixin, {
   monthLabelsArray: Ember.computed('monthLabels', function () {
     if(this.get('i18n')) {
       var i18n = this.get('i18n');
-      var i18n_prefix = this.get('i18n_prefix');
+      var i18n_prefix = this.get('i18n_prefix') + 'short.';
       return Ember.A([i18n.t(i18n_prefix + 'jan'), i18n.t(i18n_prefix + 'feb'), i18n.t(i18n_prefix + 'mar'), 
         i18n.t(i18n_prefix + 'apr'), i18n.t(i18n_prefix + 'may'), i18n.t(i18n_prefix + 'jun'), 
         i18n.t(i18n_prefix + 'jul'), i18n.t(i18n_prefix + 'aug'), i18n.t(i18n_prefix + 'sep'), 
         i18n.t(i18n_prefix + 'oct'),i18n.t(i18n_prefix + 'nov'), i18n.t(i18n_prefix + 'dec')]);
     } else {
       var monthLabels = this.get('monthLabels');
+
+      return typeof monthLabels === 'string' ? Ember.A(monthLabels.split(',')) : Ember.A(monthLabels);
+    }
+  }),
+
+  monthLabelsLongArray: Ember.computed('monthLabels', function () {
+    if(this.get('i18n')) {
+      var i18n = this.get('i18n');
+      var i18n_prefix = this.get('i18n_prefix');
+      return Ember.A([i18n.t(i18n_prefix + 'jan'), i18n.t(i18n_prefix + 'feb'), i18n.t(i18n_prefix + 'mar'), 
+        i18n.t(i18n_prefix + 'apr'), i18n.t(i18n_prefix + 'may'), i18n.t(i18n_prefix + 'jun'), 
+        i18n.t(i18n_prefix + 'jul'), i18n.t(i18n_prefix + 'aug'), i18n.t(i18n_prefix + 'sep'), 
+        i18n.t(i18n_prefix + 'oct'),i18n.t(i18n_prefix + 'nov'), i18n.t(i18n_prefix + 'dec')]);
+    } else {
+      var monthLabels = this.get('monthLabelsLong');
 
       return typeof monthLabels === 'string' ? Ember.A(monthLabels.split(',')) : Ember.A(monthLabels);
     }
@@ -183,7 +202,8 @@ export default Ember.Component.extend(DropdownComponentMixin, {
     var year = this.get('year');
 
     if (monthNumber && year) {
-      return this.get('monthLabelsArray')[monthNumber - 1] +' '+ year;
+      var labelArray = useLongTitle ? 'monthLabelsLongArray' : 'monthLabelsLongArray';
+      return this.get(labelArray)[monthNumber - 1] +' '+ year;
     } else {
       return null;
     }

--- a/addon/components/rl-month-picker.js
+++ b/addon/components/rl-month-picker.js
@@ -202,7 +202,7 @@ export default Ember.Component.extend(DropdownComponentMixin, {
     var year = this.get('year');
 
     if (monthNumber && year) {
-      var labelArray = useLongTitle ? 'monthLabelsLongArray' : 'monthLabelsLongArray';
+      var labelArray = this.get('useLongTitle') ? 'monthLabelsLongArray' : 'monthLabelsLongArray';
       return this.get(labelArray)[monthNumber - 1] +' '+ year;
     } else {
       return null;

--- a/addon/components/rl-month-picker.js
+++ b/addon/components/rl-month-picker.js
@@ -20,6 +20,10 @@ export default Ember.Component.extend(DropdownComponentMixin, {
 
   yearPicker: true,
 
+  i18n: null,
+
+  i18n_prefix: 'months.',
+
   monthPlaceholderText: 'Month',
 
   monthLabels: 'Jan,Feb,Mar,Apr,May,Jun,Jul,Aug,Sep,Oct,Nov,Dec',
@@ -107,9 +111,18 @@ export default Ember.Component.extend(DropdownComponentMixin, {
   }),
 
   monthLabelsArray: Ember.computed('monthLabels', function () {
+    if(this.get('i18n')) {
+      var i18n = this.get('i18n');
+      var i18n_prefix = this.get('i18n_prefix');
+      return Ember.A([i18n.t(i18n_prefix + 'jan'), i18n.t(i18n_prefix + 'feb'), i18n.t(i18n_prefix + 'mar'), 
+        i18n.t(i18n_prefix + 'apr'), i18n.t(i18n_prefix + 'may'), i18n.t(i18n_prefix + 'jun'), 
+        i18n.t(i18n_prefix + 'jul'), i18n.t(i18n_prefix + 'aug'), i18n.t(i18n_prefix + 'sep'), 
+        i18n.t(i18n_prefix + 'oct'),i18n.t(i18n_prefix + 'nov'), i18n.t(i18n_prefix + 'dec')]);
+    } else {
       var monthLabels = this.get('monthLabels');
 
       return typeof monthLabels === 'string' ? Ember.A(monthLabels.split(',')) : Ember.A(monthLabels);
+    }
   }),
 
   decreaseMonthButtonDisabled: Ember.computed('month', 'minMonth', function () {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-rl-month-picker",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "directories": {
     "test": "tests"
   },


### PR DESCRIPTION
Hi, I've used your ember addon in my project and it works great, however I was missing some functionality that I've added myself. Feel free to include them or parts of them in your application.

**i18n support (internationalisation)**
For my purposes I needed to have i18n support. I personally use https://github.com/jamesarosen/ember-i18n for this so this is what I implemented as well.

Parameters:
i18n: pass the i18n service in this parameter, required to activate i18n support
i18n_prefix: (default: 'months.' ) the prefix of your i18n keys

Define keys as months.short.jan: "Jan" or months.jan: "January"

**Long month name support**
For my title I wanted to be able to use long names instead of the shortened versions, so that it shows January 2016 instead of Jan 2016. In the dropdown box the short names are still used.

Parameters:
useLongTitle: (default: false) set to true to enable long titles
monthLabelsLong: (default: 'January,February,March,April,May,June,July,August,September,October,November,December') Override to set the month labels in a different format. This parameter is ignored when i18n is enabled.

**Optional yearPickerMode**
Since I'm working with short ranges (18 months max) I didn't want to display 9 years. By setting the yearPicker parameter to false, the year overview when clicking the year can be disabled. The user can still switch to years within the min/max range using the arrows ofcourse.

Parameters:
yearPicker: (default: true) set to false to disable the yearPickerMode
